### PR TITLE
Ssl fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,19 +9,14 @@ include ../../Makefile.defs
 auto_gen=
 NAME=push.so
 
-        DEFS += -I$(LOCALBASE)/ssl/include
-        LIBS += -L$(LOCALBASE)/lib -L$(LOCALBASE)/ssl/lib \
-                        -L$(LOCALBASE)/lib64 -L$(LOCALBASE)/ssl/lib64 \
-                        -lssl -lcrypto
+DEFS += -I$(LOCALBASE)/ssl/include
+LIBS += -L$(LOCALBASE)/lib -L$(LOCALBASE)/ssl/lib \
+        -L$(LOCALBASE)/lib64 -L$(LOCALBASE)/ssl/lib64 \
+        -lssl -lcrypto
 
 CFLAGS+=-g3
 #include ../../Makefile.push
 
 DEFS+=-DKAMAILIO_MOD_INTERFACE
-
-SERLIBPATH=../../lib
-SER_LIBS+=$(SERLIBPATH)/kcore/kcore
-SER_LIBS+=$(SERLIBPATH)/srdb1/srdb1
-
 
 include ../../Makefile.modules

--- a/Makefile
+++ b/Makefile
@@ -19,4 +19,7 @@ CFLAGS+=-g3
 
 DEFS+=-DKAMAILIO_MOD_INTERFACE
 
+SERLIBPATH=../../lib
+SER_LIBS+=$(SERLIBPATH)/srdb1/srdb1
+
 include ../../Makefile.modules

--- a/apns_feedback.c
+++ b/apns_feedback.c
@@ -16,7 +16,7 @@
 #include "push_ssl_utils.h"
 #include "apns_feedback.h"
 
-#include "../../dprint.h"
+#include "../../core/dprint.h"
 
 #define CHECK_FEEDBACK_TIMEOUT 3600
 

--- a/push.c
+++ b/push.c
@@ -5,10 +5,10 @@
 
 #include <arpa/inet.h>
 
-#include "../../sr_module.h"
-#include "../../dprint.h"
-#include "../../mem/mem.h"
-#include "../../parser/parse_to.h"
+#include "../../core/sr_module.h"
+#include "../../core/dprint.h"
+#include "../../core/mem/mem.h"
+#include "../../core/parser/parse_to.h"
 #include "../../lib/cds/list.h"
 #include "../../lib/srdb1/db.h"
 #include "../../lib/srdb1/db_val.h"

--- a/push_common.c
+++ b/push_common.c
@@ -23,9 +23,9 @@
 #include <sys/select.h>
 #include <sys/time.h>
 
-#include "../../dprint.h"
+#include "../../core/dprint.h"
 #include "../../lib/srdb1/db_val.h"
-#include "../../locking.h"
+#include "../../core/locking.h"
 
 #include "push_common.h"
 #include "push_ssl_utils.h"

--- a/push_common.h
+++ b/push_common.h
@@ -5,7 +5,7 @@
 
 #include "../../lib/srdb1/db.h"
 
-#define ENABLE_FEEDBACK_SERVICE
+//#define ENABLE_FEEDBACK_SERVICE
 
 #define PUSH_TABLE_VERSION 1
 

--- a/push_mod.c
+++ b/push_mod.c
@@ -33,13 +33,13 @@
 #include <arpa/inet.h>
 #include <netdb.h>
 
-#include "../../sr_module.h"
-#include "../../trim.h"
-#include "../../dprint.h"
-#include "../../mem/mem.h"
-#include "../../parser/parse_to.h"
-#include "../../parser/parse_uri.h"
-#include "../../cfg/cfg_struct.h"
+#include "../../core/sr_module.h"
+#include "../../core/trim.h"
+#include "../../core/dprint.h"
+#include "../../core/mem/mem.h"
+#include "../../core/parser/parse_to.h"
+#include "../../core/parser/parse_uri.h"
+#include "../../core/cfg/cfg_struct.h"
 
 #include "push_mod.h"
 #include "push.h"

--- a/push_ssl_utils.c
+++ b/push_ssl_utils.c
@@ -136,7 +136,7 @@ static int socket_init(const char* server, uint16_t port)
         memcpy(&sa.sin_addr, host->h_addr_list[0], host->h_length);
     }
 
-    LM_ERR("Create a socket and connect it to %s:%d\n", server, port);
+    LM_DBG("Create a socket and connect it to %s:%d\n", server, port);
     /* Create a socket and connect to server using normal socket calls. */
     sd = socket (PF_INET, SOCK_STREAM, 0);
     if (sd == -1)

--- a/push_ssl_utils.c
+++ b/push_ssl_utils.c
@@ -344,7 +344,7 @@ int send_push_data(PushServer* server, const char* buffer, uint32_t length)
     }
 
 //    read_status(server);
-    if (server->socket == -1 || server->ssl == NULL) && first_try)
+    if ((server->socket == -1 || server->ssl == NULL) && first_try)
     {
         first_try = 0;
         goto again;
@@ -449,7 +449,7 @@ int extended_read(PushServer* server,
     fd_set readfds;
     struct timeval timeout;
 
-    if ((server->socket == -1) || server->ssl == NULL) && -1 == establish_ssl_connection(server))
+    if ((server->socket == -1 || server->ssl == NULL) && -1 == establish_ssl_connection(server))
     {
         LM_ERR("extended_read failed, cannot reconnecd  initialization failed\n");
         return -1;

--- a/push_ssl_utils.c
+++ b/push_ssl_utils.c
@@ -344,7 +344,7 @@ int send_push_data(PushServer* server, const char* buffer, uint32_t length)
     }
 
 //    read_status(server);
-    if (server->socket == -1 || server->ssl == NULL) && first_try)
+    if (server->socket == -1 || server->ssl == NULL && first_try)
     {
         first_try = 0;
         goto again;
@@ -449,7 +449,7 @@ int extended_read(PushServer* server,
     fd_set readfds;
     struct timeval timeout;
 
-    if ((server->socket == -1) || server->ssl == NULL) && -1 == establish_ssl_connection(server))
+    if ((server->socket == -1) || server->ssl == NULL && -1 == establish_ssl_connection(server))
     {
         LM_ERR("extended_read failed, cannot reconnecd  initialization failed\n");
         return -1;

--- a/push_ssl_utils.c
+++ b/push_ssl_utils.c
@@ -42,7 +42,7 @@
 #include <openssl/ssl.h>
 #include <openssl/err.h>
 
-#include "../../dprint.h"
+#include "../../core/dprint.h"
 
 #include "push_common.h"
 #include "push_ssl_utils.h"


### PR DESCRIPTION
Connecting to APNS servers may succeed, but subsequently fail during SSL/TLS initialization: be sure to check that both the socket _and_ the SSL stream are available before using either of them. Fixes several potential crashes caused by a NULL SSL stream